### PR TITLE
feat: upgrade arista.eos and cisco.ios collection versions

### DIFF
--- a/environments/network/requirements.yaml
+++ b/environments/network/requirements.yaml
@@ -7,13 +7,13 @@ collections:
   - name: ansible.utils
     version: 2.10.3
   - name: arista.eos
-    version: 6.0.1
+    version: 9.0.0
   - name: cisco.aci
     version: 2.9.0
   - name: cisco.asa
     version: 4.0.1
   - name: cisco.ios
-    version: 4.6.1
+    version: 8.0.0
   - name: cisco.iosxr
     version: 5.0.3
   - name: cisco.nxos


### PR DESCRIPTION
Upgrade the arista.eos collection from 6.0.1 to 9.0.0 and the cisco.ios collection from 4.6.1 to 8.0.0 to incorporate the latest features and improvements.