### PR TITLE
chore: update ansible collection versions in network requirements

### DIFF
--- a/environments/network/requirements.yaml
+++ b/environments/network/requirements.yaml
@@ -1,32 +1,28 @@
 ---
 collections:
   - name: ansible.netcommon
-    version: 5.1.2
+    version: 6.1.2
   - name: ansible.posix
     version: 1.5.4
   - name: ansible.utils
-    version: 2.10.3
+    version: 4.1.0
   - name: arista.eos
     version: 9.0.0
   - name: cisco.aci
     version: 2.9.0
   - name: cisco.asa
-    version: 4.0.1
+    version: 5.0.1
   - name: cisco.ios
     version: 8.0.0
   - name: cisco.iosxr
-    version: 5.0.3
+    version: 9.0.0
   - name: cisco.nxos
-    version: 4.4.0
+    version: 8.1.0
   - name: community.network
-    version: 5.0.0
+    version: 5.0.2
   - name: community.routeros
     version: 2.15.0
-  - name: frr.frr
-    version: 2.0.2
   - name: junipernetworks.junos
-    version: 5.2.0
+    version: 8.0.0
   - name: pfsensible.core
     version: 0.6.1
-  - name: vyos.vyos
-    version: 4.1.0


### PR DESCRIPTION
- Update ansible.netcommon from 5.1.2 to 6.1.2
- Update ansible.utils from 2.10.3 to 4.1.0
- Update cisco.asa from 4.0.1 to 5.0.1
- Update cisco.iosxr from 5.0.3 to 9.0.0
- Update cisco.nxos from 4.4.0 to 8.1.0
- Update community.network from 5.0.0 to 5.0.2
- Update junipernetworks.junos from 5.2.0 to 8.0.0
- Remove frr.frr version 2.0.2 (deprecated)
- Remove vyos.vyos version 4.1.0 (deprecated)