### PR TITLE
chore: update execution environment dependencies and base image

### DIFF
--- a/environments/cloud/execution-environment.yaml
+++ b/environments/cloud/execution-environment.yaml
@@ -3,7 +3,7 @@ version: 3
 
 images:
   base_image:
-    name: registry.redhat.io/ansible-automation-platform-24/ee-minimal-rhel9:latest
+    name: registry.redhat.io/ansible-automation-platform/ee-minimal-rhel9@sha256:c6617b6b711eeab20b4b31a5259eac58d5244cd8f7b8ccb149847719677ee18f
 
 dependencies:
   galaxy:
@@ -11,9 +11,9 @@ dependencies:
       - { name: amazon.aws, version: 6.5.0 }
       - { name: azure.azcollection, version: 1.10.0 }
       - { name: community.aws, version: 6.3.0 }
-      - { name: community.digitalocean, version: 1.24.0 }
+      - { name: community.digitalocean, version: 1.26.0 }
       - { name: google.cloud, version: 1.2.0 }
-      - { name: hetzner.hcloud, version: 1.16.0 }
+      - { name: hetzner.hcloud, version: 4.0.1 }
       - { name: vultr.cloud, version: 1.10.0 }
   python:
     - awscli>=1.16.312


### PR DESCRIPTION
- Updated base_image to use a specific sha256 digest for ee-minimal-rhel9
- Bumped community.digitalocean collection version from 1.24.0 to 1.26.0
- Bumped hetzner.hcloud collection version from 1.16.0 to 4.0.1