### PR TITLE
chore(vmware): update execution environment dependencies

### DIFF
--- a/environments/vmware/execution-environment.yaml
+++ b/environments/vmware/execution-environment.yaml
@@ -6,8 +6,15 @@ images:
     name: registry.redhat.io/ansible-automation-platform-24/ee-minimal-rhel9:latest
 
 dependencies:
-  galaxy: requirements.yaml
-  python: requirements.txt
+  galaxy:
+    collections:
+      - { name: ansible.utils, version: 5.1.2 }
+      - { name: community.vmware, version: 5.0.1 }
+      - { name: vmware.vmware_rest, version: 4.1.0 }
+  python:
+    - aiohttp==3.8.5
+    - pyVmomi>=6.7
+    - git+https://github.com/vmware/vsphere-automation-sdk-python.git ; python_version >= '2.7' # Python 2.6 is not supported
 
 options:
   package_manager_path: /usr/bin/microdnf

--- a/environments/vmware/requirements.txt
+++ b/environments/vmware/requirements.txt
@@ -1,3 +1,0 @@
-aiohttp==3.8.5
-pyVmomi>=6.7
-git+https://github.com/vmware/vsphere-automation-sdk-python.git ; python_version >= '2.7'  # Python 2.6 is not supported

--- a/environments/vmware/requirements.yaml
+++ b/environments/vmware/requirements.yaml
@@ -1,6 +1,0 @@
----
-collections:
-  - name: community.vmware
-    version: 3.8.0
-  - name: vmware.vmware_rest
-    version: 2.3.1


### PR DESCRIPTION
- Updated the execution-environment.yaml to include specific versions of ansible.utils, community.vmware, and vmware.vmware_rest collections.
- Moved Python dependencies from requirements.txt to execution-environment.yaml, including aiohttp, pyVmomi, and vsphere-automation-sdk-python.
- Removed requirements.txt and requirements.yaml as dependencies are now managed within execution-environment.yaml.