### PR TITLE
fix: update requests-credssp version range in execution-environment.yaml

### DIFF
--- a/environments/windows/execution-environment.yaml
+++ b/environments/windows/execution-environment.yaml
@@ -16,7 +16,7 @@ dependencies:
       - { name: community.windows, version: 2.3.0 }
       - { name: microsoft.ad, version: 1.7.1 }
   python:
-    - requests-credssp > 2.2.0
+    - requests-credssp>=2.0.0,<3.0.0
 
 options:
   package_manager_path: /usr/bin/microdnf


### PR DESCRIPTION
The version range for requests-credssp in the execution-environment.yaml file has been updated from '> 2.2.0' to '>=2.0.0,<3.0.0' to ensure compatibility and prevent potential issues with future versions.